### PR TITLE
Body parser validation and class assignment in HttpUnoEvent.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - DocumentDb: Added operator Neq (Fix #48)
 - DocumentDb: Added option overwrite to set to allow pure create operation (Fix #52)
 - Templates: Support translations/resources (Fix #32)
+- Custom payload for errors + standard oauthError (Fix #56)
 - Body validation and class assignment in HttpUnoEvent
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - DocumentDb: Added operator Neq (Fix #48)
 - DocumentDb: Added option overwrite to set to allow pure create operation (Fix #52)
-- Templates: Support translations/resources (Fix #32).
-- Custom payload for errors + standard oauthError (Fix #56)
+- Templates: Support translations/resources (Fix #32)
+- Body validation and class assignment in HttpUnoEvent
 
 ### Changed
 - [BREAKING] DocumentDb: Querying with parameter id will automatically prefix the id value with the entity type if entity filter is also in the query (e.g. select().entity("orders").where<Orders>({ id: "value"})). (Fix #51)
@@ -17,9 +17,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - TokenService verify throws unauthorizedError when failing verification (instead of standard JWT error) (Fix #47)
 - Updated all dependencies to latest versions
 - Better internalization of HttpStatusCodes (Fix #55)
+- Validation can now set default values if provided
+- JSONSchema accepts format property
 
 ### Removed
-- Deprecated buildNonStandardError method. Replaced by buildErrorWithCustomPayload. (Fix #56)
+- Deprecated buildNonStandardError method in favor of buildErrorWithCustomPayload (Fix #56)
+- Deprecated validateBody middleware in favor of event.body({ validate: schema})
 
 ## [0.47.0] - 2018-08-13
 ### Added

--- a/packages/uno-serverless-aws/src/adapter.ts
+++ b/packages/uno-serverless-aws/src/adapter.ts
@@ -1,8 +1,11 @@
 import {
-  GenericFunctionBuilder, HttpUnoEvent, isHttpUnoResponse,
-  ProviderAdapter, UnoContext } from "uno-serverless";
+  BodyOptions, GenericFunctionBuilder, HttpUnoEvent,
+  isHttpUnoResponse, ProviderAdapter, UnoContext } from "uno-serverless";
 
-const throwBody = () => { throw new Error("Unable to parse body. Did you forget to add a middleware?"); };
+const throwBody = (options?: BodyOptions<any>) => {
+  throw new Error("Unable to parse body. Did you forget to add a middleware?");
+};
+
 const defaultPrincipal = async (throwIfEmpty = true) => {
   if (throwIfEmpty) {
     throw new Error("Unable to retrieve principal. Did you forget to add a middleware?");

--- a/packages/uno-serverless-aws/test/unit/handlers/authorizer-test.ts
+++ b/packages/uno-serverless-aws/test/unit/handlers/authorizer-test.ts
@@ -56,7 +56,7 @@ describe("authorizerBearer handler", () => {
         },
         createLambdaContext(),
         (e, r) => { });
-      expect(false);
+      expect.fail();
     } catch (error) {
       expect(error.code).to.equal(StandardErrorCodes.Unauthorized);
     }

--- a/packages/uno-serverless-aws/test/unit/services/config-test.ts
+++ b/packages/uno-serverless-aws/test/unit/services/config-test.ts
@@ -66,7 +66,7 @@ describe("SSMParameterStoreConfigService", () => {
 
     try {
       await config.get("foo");
-      expect(false);
+      expect.fail();
     } catch (error) {
       expect(error.code).to.equal(StandardErrorCodes.ConfigurationError);
       expect(error.data.key).to.equal("foo");
@@ -75,7 +75,7 @@ describe("SSMParameterStoreConfigService", () => {
 
     try {
       await config.get("foo", true);
-      expect(false);
+      expect.fail();
     } catch (error) {
       expect(error.code).to.equal(StandardErrorCodes.ConfigurationError);
       expect(error.data.key).to.equal("foo");

--- a/packages/uno-serverless-azure/src/adapter.ts
+++ b/packages/uno-serverless-azure/src/adapter.ts
@@ -1,6 +1,6 @@
 import {
-  GenericFunctionBuilder, HttpStatusCodes, HttpUnoEvent,
-  ProviderAdapter, UnoContext, UnoEvent } from "uno-serverless";
+  applyBodyOptions, BodyOptions, GenericFunctionBuilder,
+  HttpStatusCodes, HttpUnoEvent, ProviderAdapter, UnoContext, UnoEvent } from "uno-serverless";
 import { AzureFunctionsContext, AzureFunctionsHttpEvent, AzureFunctionsHttpResponse } from "./azure-functions-schemas";
 
 const defaultPrincipal = async (throwIfEmpty = true) => {
@@ -31,7 +31,7 @@ export const azureFunctionAdapter = (): ProviderAdapter => {
           if (typeof event === "object" && typeof event !== "string" && "method" in event) {
             const azHttpEvent = event as AzureFunctionsHttpEvent;
             const httpUnoEvent: HttpUnoEvent = {
-              body: () => azHttpEvent.body,
+              body: (options?: BodyOptions<any>) => applyBodyOptions(azHttpEvent.body, options),
               headers: azHttpEvent.headers || {},
               httpMethod: azHttpEvent.method && azHttpEvent.method.toLowerCase(),
               original: azHttpEvent,

--- a/packages/uno-serverless-jwt/test/unit/middlewares/http-test.ts
+++ b/packages/uno-serverless-jwt/test/unit/middlewares/http-test.ts
@@ -35,7 +35,7 @@ describe("principalFromBearerToken", () => {
           authorization: "",
         },
       });
-      expect(false);
+      expect.fail();
     } catch (error) {
       expect(error.code).to.equal(StandardErrorCodes.Unauthorized);
     }

--- a/packages/uno-serverless-jwt/test/unit/services/signing-key-service-test.ts
+++ b/packages/uno-serverless-jwt/test/unit/services/signing-key-service-test.ts
@@ -34,7 +34,7 @@ describe("JWKSigningKeyService", () => {
   it("should throw if keyId is not provided.", async () => {
     try {
       await provider.getSecretOrPublicKey();
-      expect(false);
+      expect.fail();
     } catch (error) {
       expect(error.message).to.contain("keyId");
     }
@@ -43,7 +43,7 @@ describe("JWKSigningKeyService", () => {
   it("should throw if key cannot be found.", async () => {
     try {
       await provider.getSecretOrPublicKey(randomStr());
-      expect(false);
+      expect.fail();
     } catch (error) {
       expect(error.message).to.contain("find key");
     }
@@ -52,7 +52,7 @@ describe("JWKSigningKeyService", () => {
   it("should throw if asked for private key.", async () => {
     try {
       await provider.getSecretOrPrivateKey();
-      expect(false);
+      expect.fail();
     } catch (error) {
       expect(error.message).to.contain("private");
     }

--- a/packages/uno-serverless-jwt/test/unit/services/token-service-test.ts
+++ b/packages/uno-serverless-jwt/test/unit/services/token-service-test.ts
@@ -84,7 +84,7 @@ describe("JWTTokenService", () => {
 
     try {
       await service.verify<typeof payload & TokenClaims>(alteredToken);
-      expect(false);
+      expect.fail();
     } catch (error) {
       expect(error.code).to.equal(StandardErrorCodes.Unauthorized);
       expect(error.message).to.contain("invalid token");

--- a/packages/uno-serverless/.vscode/settings.json
+++ b/packages/uno-serverless/.vscode/settings.json
@@ -4,7 +4,8 @@
         "deserialized",
         "deserializer",
         "memoization",
-        "memoized"
+        "memoized",
+        "middlewares"
     ],
     "files.exclude": {
       "**/coverage": true,

--- a/packages/uno-serverless/src/core/json-schema.ts
+++ b/packages/uno-serverless/src/core/json-schema.ts
@@ -1,27 +1,5 @@
-/**
- * MIT License
- *
- * Copyright (c) 2016 Richard Adams (https://github.com/enriched)
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
 
+/** JSON schema format for validation. */
 export interface JSONSchema {
   $ref?: string;
   /////////////////////////////////////////////////
@@ -80,6 +58,8 @@ export interface JSONSchema {
    * conform to
    */
   pattern?: string;
+
+  format?: string;
 
   /////////////////////////////////////////////////
   // Array Validation

--- a/packages/uno-serverless/src/core/schemas.ts
+++ b/packages/uno-serverless/src/core/schemas.ts
@@ -1,3 +1,4 @@
+import { JSONSchema } from "./json-schema";
 
 export type UnoEventType = "any" | "http";
 
@@ -21,6 +22,13 @@ export interface UnoContext {
 
 export type HttpMethod = "get" | "head" | "options" | "post" | "put" | "patch" | "delete" | "trace" | "connect";
 
+export interface BodyOptions<T> {
+  /** After de-serialization, validate the object using this schema. */
+  validate?: JSONSchema;
+  /** Assign the parsed object to a specific class. */
+  assignClass?: { new(...args: any[]): T ; };
+}
+
 export interface HttpUnoEvent extends UnoEvent {
   headers: Record<string, string>;
   httpMethod: HttpMethod | string;
@@ -28,7 +36,7 @@ export interface HttpUnoEvent extends UnoEvent {
   parameters: Record<string, string>;
   rawBody: string;
   url: string;
-  body<T>(): T;
+  body<T>(options?: BodyOptions<T>): T;
   principal<T>(): Promise<T>;
   principal<T>(throwIfEmpty: false): Promise<T | undefined>;
 }

--- a/packages/uno-serverless/src/core/validator.ts
+++ b/packages/uno-serverless/src/core/validator.ts
@@ -4,6 +4,7 @@ import { JSONSchema } from "./json-schema";
 
 const ajv = new Ajv({
   allErrors: true,
+  useDefaults: true,
 });
 
 /**

--- a/packages/uno-serverless/test/unit/core/errors-test.ts
+++ b/packages/uno-serverless/test/unit/core/errors-test.ts
@@ -65,7 +65,7 @@ describe("dependencyErrorProxy", () => {
 
     try {
       proxy.standardFunc(true);
-      expect(false);
+      expect.fail();
     } catch (error) {
       expect(error.code).to.equal(StandardErrorCodes.DependencyError);
       expect(error.target).to.equal("TestTarget");
@@ -88,7 +88,7 @@ describe("dependencyErrorProxy", () => {
 
     try {
       await proxy.promiseFunc(true);
-      expect(false);
+      expect.fail();
     } catch (error) {
       expect(error.code).to.equal(StandardErrorCodes.DependencyError);
       expect(error.target).to.equal("TestTarget");
@@ -101,7 +101,7 @@ describe("dependencyErrorProxy", () => {
 
     try {
       proxy.managedError();
-      expect(false);
+      expect.fail();
     } catch (error) {
       expect(error.code).to.equal(StandardErrorCodes.InternalServerError);
     }

--- a/packages/uno-serverless/test/unit/events/event-dispatcher-test.ts
+++ b/packages/uno-serverless/test/unit/events/event-dispatcher-test.ts
@@ -70,7 +70,7 @@ describe("LocalEventDispatcher", () => {
         id: randomStr(12),
         type: EventTypes.NewUser,
       });
-      expect(false);
+      expect.fail();
     } catch (error) {
       expect(error.message).to.equal(thrownError.message);
       expect(allRun).to.equal(1);
@@ -98,7 +98,7 @@ describe("LocalEventDispatcher", () => {
         id: randomStr(12),
         type: EventTypes.NewUser,
       });
-      expect(false);
+      expect.fail();
     } catch (error) {
       expect(error.code).to.equal(StandardErrorCodes.AggregateError);
       expect(error.details[0].message).to.equal(thrownError1.message);

--- a/packages/uno-serverless/test/unit/handlers/http-test.ts
+++ b/packages/uno-serverless/test/unit/handlers/http-test.ts
@@ -30,7 +30,7 @@ describe("http handler", () => {
 
     try {
       await handler();
-      expect(false);
+      expect.fail();
     } catch (error) {
       expect(error.code).to.equal(StandardErrorCodes.NotFound);
       expect(error.getStatusCode()).to.equal(HttpStatusCodes.NOT_FOUND);
@@ -84,7 +84,7 @@ describe("httpMethodMethod handler", () => {
         {
           httpMethod: "options",
         });
-      expect(false);
+      expect.fail();
     } catch (error) {
       expect(error.code).to.equal(StandardErrorCodes.MethodNotAllowed);
       expect(error.getStatusCode()).to.equal(HttpStatusCodes.METHOD_NOT_ALLOWED);
@@ -156,7 +156,7 @@ describe("httpRouter handler", () => {
           },
           url: "/api/users",
         });
-      expect(false);
+      expect.fail();
     } catch (error) {
       expect(error.code).to.equal(StandardErrorCodes.MethodNotAllowed);
     }
@@ -180,7 +180,7 @@ describe("httpRouter handler", () => {
           },
           url: "/api/users/foo",
         });
-      expect(false);
+      expect.fail();
     } catch (error) {
       expect(error.code).to.equal(StandardErrorCodes.NotFound);
     }

--- a/packages/uno-serverless/test/unit/middlewares/logging-test.ts
+++ b/packages/uno-serverless/test/unit/middlewares/logging-test.ts
@@ -17,7 +17,7 @@ describe("errorLogging middleware", () => {
         {
           bar: "bar",
         });
-      expect(false);
+      expect.fail();
     } catch (error) {
       expect(logged).to.not.be.undefined;
       expect(logged).to.contain("foo");

--- a/packages/uno-serverless/test/unit/middlewares/validation-test.ts
+++ b/packages/uno-serverless/test/unit/middlewares/validation-test.ts
@@ -31,7 +31,7 @@ describe("validateEvent middleware", () => {
         {
           foo: randomStr(),
         });
-      expect(false);
+      expect.fail();
     } catch (error) {
       expect(error.code).to.equal(StandardErrorCodes.ValidationError);
     }
@@ -65,10 +65,10 @@ describe("validateBody middleware", () => {
     try {
       await handler(
         {
-          body: JSON.stringify({ foo: "foo" }),
           httpMethod: "put",
+          rawBody: JSON.stringify({ foo: "foo" }),
         });
-      expect(false);
+      expect.fail();
     } catch (error) {
       expect(error.code).to.equal(StandardErrorCodes.ValidationError);
     }
@@ -87,9 +87,9 @@ describe("validateBody middleware", () => {
         {
           httpMethod: "post",
         });
-      expect(false);
+      expect.fail();
     } catch (error) {
-      expect(error.code).to.equal(StandardErrorCodes.ValidationError);
+      expect(error.code).to.equal(StandardErrorCodes.BadRequest);
     }
   });
 
@@ -118,7 +118,7 @@ describe("validateBody middleware", () => {
         {
           httpMethod: "patch",
         });
-      expect(false);
+      expect.fail();
     } catch (error) {
       expect(error.message).to.contain("body");
     }
@@ -146,25 +146,11 @@ describe("validateParameters middleware", () => {
     try {
       await handler(
         {
-          pathParameters: { bar: "foo" },
-          queryStringParameters: { id: "5" },
+          parameters: { bar: "foo", id: "5" },
         });
-      expect(false);
+      expect.fail();
     } catch (error) {
       expect(error.code).to.equal(StandardErrorCodes.ValidationError);
-    }
-  });
-
-  it("should throw if missing parameters.", async () => {
-    const handler = uno(testAdapter())
-      .use(validateParameters({}))
-      .handler(async () => { });
-
-    try {
-      await handler();
-      expect(false);
-    } catch (error) {
-      expect(error.message).to.contain("parameters");
     }
   });
 

--- a/packages/uno-serverless/test/unit/services/config-test.ts
+++ b/packages/uno-serverless/test/unit/services/config-test.ts
@@ -29,7 +29,7 @@ describe("StaticConfigService", () => {
 
     try {
       await config.get("foo");
-      expect(false);
+      expect.fail();
     } catch (error) {
       expect(error.code).to.equal(StandardErrorCodes.ConfigurationError);
       expect(error.data.key).to.equal("foo");
@@ -38,7 +38,7 @@ describe("StaticConfigService", () => {
 
     try {
       await config.get("foo", true);
-      expect(false);
+      expect.fail();
     } catch (error) {
       expect(error.code).to.equal(StandardErrorCodes.ConfigurationError);
       expect(error.data.key).to.equal("foo");
@@ -70,7 +70,7 @@ describe("ProcessEnvConfigService", () => {
 
     try {
       await config.get("foo");
-      expect(false);
+      expect.fail();
     } catch (error) {
       expect(error.code).to.equal(StandardErrorCodes.ConfigurationError);
       expect(error.data.key).to.equal("foo");
@@ -79,7 +79,7 @@ describe("ProcessEnvConfigService", () => {
 
     try {
       await config.get("foo", true);
-      expect(false);
+      expect.fail();
     } catch (error) {
       expect(error.code).to.equal(StandardErrorCodes.ConfigurationError);
       expect(error.data.key).to.equal("foo");
@@ -117,7 +117,7 @@ describe("JSONFileConfigService", () => {
 
     try {
       await config.get("missing");
-      expect(false);
+      expect.fail();
     } catch (error) {
       expect(error.code).to.equal(StandardErrorCodes.ConfigurationError);
       expect(error.data.key).to.equal("missing");
@@ -126,7 +126,7 @@ describe("JSONFileConfigService", () => {
 
     try {
       await config.get("missing", true);
-      expect(false);
+      expect.fail();
     } catch (error) {
       expect(error.code).to.equal(StandardErrorCodes.ConfigurationError);
       expect(error.data.key).to.equal("missing");
@@ -142,7 +142,7 @@ describe("JSONFileConfigService", () => {
 
     try {
       await config.get("foo", false);
-      expect(false);
+      expect.fail();
     } catch (error) {
       expect(error.message).to.contain(path);
     }

--- a/packages/uno-serverless/test/unit/services/http-client-test.ts
+++ b/packages/uno-serverless/test/unit/services/http-client-test.ts
@@ -155,7 +155,7 @@ describe("httpClientFactory", () => {
       const data = { title: randomStr() };
       try {
         await test(client, postId, data);
-        expect(false);
+        expect.fail();
       } catch (error) {
         const httpClientError = error as HttpClientError;
         expect(httpClientError.response!.status).to.equal(HttpStatusCodes.NOT_FOUND);

--- a/packages/uno-serverless/test/unit/services/symmetric-encryption-service-test.ts
+++ b/packages/uno-serverless/test/unit/services/symmetric-encryption-service-test.ts
@@ -15,7 +15,7 @@ describe("AES256GCMSymmetricEncryptionService", () => {
 
     try {
       await cryptoService.decrypt(randomStr());
-      expect(false);
+      expect.fail();
     } catch (error) {
       expect(error.message).to.not.be.undefined;
     }


### PR DESCRIPTION
Validation can now be utilized in the context of httpRouter more naturally.

+ expect(false) in the code base did not work as intended. Must use expect.fail().