### PR TITLE
Default behavior for AWS authorizerBearer handler is to throw "Unauth…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Fixed issue in S3 KeyValueRepository list implementation not returning results (Fix #79)
+- Default behavior for AWS authorizerBearer handler is to throw "Unauthorized" on caught errors (Fix #78)
 
 ## [0.51] - 2018-09-19
 ### Added

--- a/packages/uno-serverless-aws/test/unit/handlers/authorizer-test.ts
+++ b/packages/uno-serverless-aws/test/unit/handlers/authorizer-test.ts
@@ -44,8 +44,13 @@ describe("authorizerBearer handler", () => {
       principalId: bearerToken,
     });
 
+    let caughtError: any;
+
     const handler = uno(awsLambdaAdapter())
-      .handler(authorizerBearer(async ({ bearerToken }) => authorizerResult(bearerToken)));
+      .handler(authorizerBearer(
+        async ({ bearerToken }) => authorizerResult(bearerToken),
+        // tslint:disable-next-line:no-string-throw
+        (error) => { caughtError = error; throw "Unauthorized"; }));
 
     try {
       await handler(
@@ -58,7 +63,8 @@ describe("authorizerBearer handler", () => {
         (e, r) => { });
       expect.fail();
     } catch (error) {
-      expect(error.code).to.equal(StandardErrorCodes.Unauthorized);
+      expect(error).to.equal("Unauthorized");
+      expect(caughtError.code).to.equal(StandardErrorCodes.Unauthorized);
     }
   });
 


### PR DESCRIPTION
…orized" on caught errors

Fix #78